### PR TITLE
Fix logging JSON issues and enable API routes

- Fix MCP Server logging to prevent JSON syntax errors in Pail
- Reduce complex parameter logging that could cause malformed JSON
- Replace stack trace logging with simplified error info
- Add missing API routes configuration in bootstrap/app.php
- Add MCP health endpoint at /api/mcp/health
- Clean up redundant API route definitions

This resolves the JsonException in Pail logging system and enables
Proper API endpoint access for MCP server functionality.

### DIFF
--- a/app/Services/McpServer.php
+++ b/app/Services/McpServer.php
@@ -18,7 +18,11 @@ class McpServer
             $method = $request['method'] ?? null;
             $params = $request['params'] ?? [];
 
-            Log::info('MCP Server received request', ['method' => $method, 'params' => $params]);
+            Log::info('MCP Server received request', [
+                'method' => $method,
+                'params_count' => count($params),
+                'has_params' => ! empty($params),
+            ]);
 
             return match ($method) {
                 'initialize' => $this->initialize($params),
@@ -31,7 +35,11 @@ class McpServer
                 default => $this->errorResponse('Unknown method', -32601)
             };
         } catch (\Exception $e) {
-            Log::error('MCP Server error', ['error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            Log::error('MCP Server error', [
+                'error' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
 
             return $this->errorResponse($e->getMessage(), -32603);
         }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,13 @@ Route::get('/user', function (Request $request) {
 
 // MCP Server endpoints
 Route::post('/mcp', [McpController::class, 'handle'])->name('mcp.handle');
-Route::post('/mcp/tools', [McpController::class, 'handle'])->name('mcp.tools');
-Route::post('/mcp/resources', [McpController::class, 'handle'])->name('mcp.resources');
-Route::post('/mcp/prompts', [McpController::class, 'handle'])->name('mcp.prompts');
+
+// Health check endpoint
+Route::get('/mcp/health', function () {
+    return response()->json([
+        'status' => 'ok',
+        'service' => 'MCP Server',
+        'version' => '1.0.0',
+        'timestamp' => now()->toISOString(),
+    ]);
+})->name('mcp.health');


### PR DESCRIPTION
## Summary
Fix logging JSON issues and enable API routes

- Fix MCP Server logging to prevent JSON syntax errors in Pail
- Reduce complex parameter logging that could cause malformed JSON
- Replace stack trace logging with simplified error info
- Add missing API routes configuration in bootstrap/app.php
- Add MCP health endpoint at /api/mcp/health
- Clean up redundant API route definitions

This resolves the JsonException in Pail logging system and enables
Proper API endpoint access for MCP server functionality.

## Changes
- app/Services/McpServer.php
- bootstrap/app.php
- routes/api.php

🤖 Generated with [Claude Code](https://claude.ai/code)