### PR TITLE
Fix form validation error in MCP Conversation page

[selectedConnection]' error
- Change loadTools() method to use ->data instead of ->form->getState()
- Avoid form validation when accessing connection data from header actions
- Improve error handling in loadTools() method

This resolves the validation error when clicking 'Refresh Tools' button
Before selecting a connection in the MCP Conversation interface.

### DIFF
--- a/app/Filament/Pages/McpConversation.php
+++ b/app/Filament/Pages/McpConversation.php
@@ -263,18 +263,21 @@ class McpConversation extends Page implements HasForms
 
     public function loadTools(): void
     {
-        $formData = $this->form->getState();
+        // Use the data property instead of form state to avoid validation errors
+        $selectedConnection = $this->data['selectedConnection'] ?? null;
 
-        if (empty($formData['selectedConnection'])) {
+        if (empty($selectedConnection)) {
             $this->availableTools = [];
 
             return;
         }
 
         try {
-            $connection = McpConnection::find($formData['selectedConnection']);
+            $connection = McpConnection::find($selectedConnection);
 
             if (! $connection) {
+                $this->availableTools = [];
+
                 return;
             }
 


### PR DESCRIPTION
## Summary
Fix form validation error in MCP Conversation page

[selectedConnection]' error
- Change loadTools() method to use ->data instead of ->form->getState()
- Avoid form validation when accessing connection data from header actions
- Improve error handling in loadTools() method

This resolves the validation error when clicking 'Refresh Tools' button
Before selecting a connection in the MCP Conversation interface.

## Changes
- app/Filament/Pages/McpConversation.php

🤖 Generated with [Claude Code](https://claude.ai/code)