### PR TITLE
Fix empty content area in MCP Conversation page

- Add missing protected static $view property to specify Blade template
- Rename conversationForm() method to form() for proper Filament integration
- Ensure Filament page renders the form and content correctly

This resolves the issue where /admin/mcp-conversation showed only
Title and buttons with empty content area.

### DIFF
--- a/app/Filament/Pages/McpConversation.php
+++ b/app/Filament/Pages/McpConversation.php
@@ -23,6 +23,8 @@ class McpConversation extends Page implements HasForms
 
     protected static ?string $navigationLabel = 'Chat with Claude';
 
+    protected static string $view = 'filament.pages.mcp-conversation';
+
     public ?array $data = [];
 
     public array $conversation = [];
@@ -35,7 +37,7 @@ class McpConversation extends Page implements HasForms
         $this->loadAvailableConnections();
     }
 
-    public function conversationForm(Form $form): Form
+    public function form(Form $form): Form
     {
         return $form
             ->schema($this->getFormSchema())


### PR DESCRIPTION
## Summary
Fix empty content area in MCP Conversation page

- Add missing protected static $view property to specify Blade template
- Rename conversationForm() method to form() for proper Filament integration
- Ensure Filament page renders the form and content correctly

This resolves the issue where /admin/mcp-conversation showed only
Title and buttons with empty content area.

## Changes
- app/Filament/Pages/McpConversation.php

🤖 Generated with [Claude Code](https://claude.ai/code)