### PR TITLE
Set stdio defaults for MCP Connection form

- Added default value '/usr/bin/claude mcp serve' for endpoint_url field
- Transport type was already defaulting to 'stdio'
- Makes it easier to create Claude Code stdio connections
- Users can simply enter a name and save without changing other fields

### DIFF
--- a/app/Filament/Resources/McpConnections/McpConnectionResource.php
+++ b/app/Filament/Resources/McpConnections/McpConnectionResource.php
@@ -33,6 +33,7 @@ class McpConnectionResource extends Resource
                 TextInput::make('endpoint_url')
                     ->label('Endpoint URL')
                     ->helperText('For HTTP/WebSocket: enter URL (e.g. http://localhost:3000). For stdio: enter command path (e.g. /usr/bin/claude mcp serve)')
+                    ->default('/usr/bin/claude mcp serve')
                     ->required(),
 
                 Select::make('transport_type')


### PR DESCRIPTION
## Summary
Set stdio defaults for MCP Connection form

- Added default value '/usr/bin/claude mcp serve' for endpoint_url field
- Transport type was already defaulting to 'stdio'
- Makes it easier to create Claude Code stdio connections
- Users can simply enter a name and save without changing other fields

## Changes
- app/Filament/Resources/McpConnections/McpConnectionResource.php

🤖 Generated with [Claude Code](https://claude.ai/code)