### PR TITLE
Fix command format for Laravel Process API

- Split command string into array using explode(' ', $command)
- Laravel Process API expects command as array when using ->run()
- This should resolve the remaining input() method error
- Allows stdio transport to properly execute 'claude mcp serve' command

### DIFF
--- a/app/Services/McpClient.php
+++ b/app/Services/McpClient.php
@@ -215,8 +215,10 @@ class McpClient
         $jsonRequest = json_encode($request);
 
         // Run the process with input
+        // Split command into array if it contains spaces
+        $commandArray = explode(' ', $command);
         $result = Process::input($jsonRequest)
-            ->run($command);
+            ->run($commandArray);
 
         if (! $result->successful()) {
             throw new \Exception('Process failed: '.$result->errorOutput());


### PR DESCRIPTION
## Summary
Fix command format for Laravel Process API

- Split command string into array using explode(' ', $command)
- Laravel Process API expects command as array when using ->run()
- This should resolve the remaining input() method error
- Allows stdio transport to properly execute 'claude mcp serve' command

## Changes
- app/Services/McpClient.php

🤖 Generated with [Claude Code](https://claude.ai/code)