### PR TITLE
Fix form data access in MCP Conversation page

- Changed from using $this->form->getState() to $this->data for data access
- Fixed mismatch between button disabled condition and sendMessage method
- Updated sendMessage and callTool methods to use consistent data property
- Added proper validation notification when required fields are empty
- Ensures Send Message button functionality works correctly

This fixes the issue where clicking Send Message button did nothing.

### DIFF
--- a/app/Filament/Pages/McpConversation.php
+++ b/app/Filament/Pages/McpConversation.php
@@ -113,9 +113,18 @@ class McpConversation extends Page implements HasForms
 
     public function sendMessage(): void
     {
-        $formData = $this->form->getState();
+        // Validate form first
+        $this->form->getState();
+
+        // Use the data property which is where form data is stored
+        $formData = $this->data;
 
         if (empty($formData['message']) || empty($formData['selectedConnection'])) {
+            Notification::make()
+                ->title('Please fill in all required fields')
+                ->warning()
+                ->send();
+
             return;
         }
 
@@ -162,7 +171,7 @@ class McpConversation extends Page implements HasForms
                 ];
             }
 
-            $this->form->fill(['message' => '']);
+            $this->data['message'] = '';
 
             Notification::make()
                 ->title('Message sent successfully')
@@ -188,7 +197,8 @@ class McpConversation extends Page implements HasForms
 
     public function callTool(): void
     {
-        $formData = $this->form->getState();
+        $this->form->getState();
+        $formData = $this->data;
 
         if (empty($formData['selectedTool']) || empty($formData['selectedConnection'])) {
             return;
@@ -233,7 +243,8 @@ class McpConversation extends Page implements HasForms
                 ];
             }
 
-            $this->form->fill(['selectedTool' => null, 'toolArguments' => []]);
+            $this->data['selectedTool'] = null;
+            $this->data['toolArguments'] = [];
 
             Notification::make()
                 ->title('Tool executed successfully')


### PR DESCRIPTION
## Summary
Fix form data access in MCP Conversation page

- Changed from using $this->form->getState() to $this->data for data access
- Fixed mismatch between button disabled condition and sendMessage method
- Updated sendMessage and callTool methods to use consistent data property
- Added proper validation notification when required fields are empty
- Ensures Send Message button functionality works correctly

This fixes the issue where clicking Send Message button did nothing.

## Changes
- app/Filament/Pages/McpConversation.php

🤖 Generated with [Claude Code](https://claude.ai/code)