### PR TITLE
Replace custom health cards with genuine Filament v4 widgets in system health page - Two rows of 4x25% width widgets with auto-refresh and proper health data integration

### DIFF
--- a/app/Filament/Pages/McpSystemHealth.php
+++ b/app/Filament/Pages/McpSystemHealth.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\Pages;
 
+use App\Filament\Widgets\HealthOverviewWidget;
+use App\Filament\Widgets\SystemComponentsWidget;
 use App\Services\McpHealthCheckService;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
@@ -18,6 +20,22 @@ class McpSystemHealth extends Page
     public function getView(): string
     {
         return 'filament.pages.mcp-system-health';
+    }
+
+    public function getHeaderWidgets(): array
+    {
+        return [
+            HealthOverviewWidget::class,
+            SystemComponentsWidget::class,
+        ];
+    }
+
+    public function getHeaderWidgetsColumns(): int|array
+    {
+        return [
+            'md' => 4,
+            'xl' => 4,
+        ];
     }
 
     public array $healthData = [];
@@ -187,43 +205,12 @@ class McpSystemHealth extends Page
         };
     }
 
-    public function getHealthCards(): array
+    /**
+     * Get health data for widgets and page content
+     */
+    public function getHealthData(): array
     {
-        $score = $this->healthData['score'] ?? 0;
-        $status = $this->healthData['status'] ?? 'unknown';
-        $lastCheck = $this->healthData['last_check'] ?? null;
-        $responseTime = $this->healthData['performance']['Response Time'] ?? 'Unknown';
-
-        return [
-            [
-                'label' => 'Overall Health',
-                'value' => $score.'/100',
-                'description' => ucfirst($status),
-                'icon' => $this->getStatusIcon(),
-                'color' => $this->getStatusColor(),
-            ],
-            [
-                'label' => 'Response Time',
-                'value' => $responseTime,
-                'description' => $this->healthData['performance']['Assessment'] ?? 'Unknown',
-                'icon' => 'heroicon-o-clock',
-                'color' => ($this->healthData['performance']['Assessment'] ?? '') === 'fast' ? 'success' : 'warning',
-            ],
-            [
-                'label' => 'System Issues',
-                'value' => count($this->healthData['errors'] ?? []),
-                'description' => 'Active problems',
-                'icon' => 'heroicon-o-exclamation-triangle',
-                'color' => count($this->healthData['errors'] ?? []) === 0 ? 'success' : 'danger',
-            ],
-            [
-                'label' => 'Last Check',
-                'value' => $lastCheck ? \Carbon\Carbon::parse($lastCheck)->diffForHumans() : 'Never',
-                'description' => 'Health verification',
-                'icon' => 'heroicon-o-clock',
-                'color' => 'info',
-            ],
-        ];
+        return $this->healthData;
     }
 
     // Auto-refresh every 60 seconds

--- a/app/Filament/Widgets/HealthOverviewWidget.php
+++ b/app/Filament/Widgets/HealthOverviewWidget.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Services\McpHealthCheckService;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class HealthOverviewWidget extends BaseWidget
+{
+    protected static ?int $sort = 1;
+
+    protected function getStats(): array
+    {
+        $healthService = app(McpHealthCheckService::class);
+        $healthData = $healthService->getHealthDashboardData();
+
+        return [
+            Stat::make('Overall Health', $healthData['score'].'/100')
+                ->description(ucfirst($healthData['status'] ?? 'unknown'))
+                ->descriptionIcon($this->getStatusIcon($healthData['status'] ?? 'unknown'))
+                ->color($this->getStatusColor($healthData['status'] ?? 'unknown')),
+
+            Stat::make('Response Time', $healthData['performance']['Response Time'] ?? 'Unknown')
+                ->description($healthData['performance']['Assessment'] ?? 'Unknown')
+                ->descriptionIcon('heroicon-o-clock')
+                ->color(($healthData['performance']['Assessment'] ?? '') === 'fast' ? 'success' : 'warning'),
+
+            Stat::make('System Issues', count($healthData['errors'] ?? []))
+                ->description('Active problems')
+                ->descriptionIcon('heroicon-o-exclamation-triangle')
+                ->color(count($healthData['errors'] ?? []) === 0 ? 'success' : 'danger'),
+
+            Stat::make('Last Check', $this->formatLastCheck($healthData['last_check'] ?? null))
+                ->description('Health verification')
+                ->descriptionIcon('heroicon-o-clock')
+                ->color('info'),
+        ];
+    }
+
+    private function getStatusIcon(string $status): string
+    {
+        return match ($status) {
+            'excellent' => 'heroicon-o-check-circle',
+            'good' => 'heroicon-o-check-badge',
+            'fair' => 'heroicon-o-exclamation-triangle',
+            'poor' => 'heroicon-o-x-circle',
+            'critical', 'error' => 'heroicon-o-x-circle',
+            default => 'heroicon-o-question-mark-circle',
+        };
+    }
+
+    private function getStatusColor(string $status): string
+    {
+        return match ($status) {
+            'excellent' => 'success',
+            'good' => 'primary',
+            'fair' => 'warning',
+            'poor' => 'danger',
+            'critical', 'error' => 'danger',
+            default => 'gray',
+        };
+    }
+
+    private function formatLastCheck(?string $lastCheck): string
+    {
+        if (! $lastCheck) {
+            return 'Never';
+        }
+
+        try {
+            return \Carbon\Carbon::parse($lastCheck)->diffForHumans();
+        } catch (\Exception $e) {
+            return 'Unknown';
+        }
+    }
+
+    protected ?string $pollingInterval = '60s'; // Refresh every 60 seconds
+}

--- a/app/Filament/Widgets/SystemComponentsWidget.php
+++ b/app/Filament/Widgets/SystemComponentsWidget.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Services\McpHealthCheckService;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class SystemComponentsWidget extends BaseWidget
+{
+    protected static ?int $sort = 2;
+
+    protected function getStats(): array
+    {
+        $healthService = app(McpHealthCheckService::class);
+        $healthData = $healthService->getHealthDashboardData();
+        $components = $healthData['components'] ?? [];
+
+        return [
+            Stat::make('Claude CLI', $components['Claude CLI'] ?? 'Unknown')
+                ->description('Command line interface')
+                ->descriptionIcon('heroicon-o-command-line')
+                ->color($this->getComponentColor($components['Claude CLI'] ?? 'Unknown')),
+
+            Stat::make('Authentication', $components['Authentication'] ?? 'Unknown')
+                ->description('API key validation')
+                ->descriptionIcon('heroicon-o-key')
+                ->color($this->getComponentColor($components['Authentication'] ?? 'Unknown')),
+
+            Stat::make('MCP Server', $components['MCP Server'] ?? 'Unknown')
+                ->description('Protocol server')
+                ->descriptionIcon('heroicon-o-server')
+                ->color($this->getComponentColor($components['MCP Server'] ?? 'Unknown')),
+
+            Stat::make('Connection Pool', $this->getActiveConnections())
+                ->description('Active connections')
+                ->descriptionIcon('heroicon-o-link')
+                ->color('info'),
+        ];
+    }
+
+    private function getComponentColor(string $status): string
+    {
+        return match (strtolower($status)) {
+            'available', 'valid', 'responsive' => 'success',
+            'unavailable', 'invalid', 'unresponsive' => 'danger',
+            default => 'warning',
+        };
+    }
+
+    private function getActiveConnections(): string
+    {
+        try {
+            $connections = \App\Models\McpConnection::where('status', 'active')->count();
+
+            return (string) $connections;
+        } catch (\Exception $e) {
+            return '0';
+        }
+    }
+
+    protected ?string $pollingInterval = '60s'; // Refresh every 60 seconds
+}

--- a/resources/views/filament/pages/mcp-system-health.blade.php
+++ b/resources/views/filament/pages/mcp-system-health.blade.php
@@ -1,74 +1,10 @@
 <x-filament-panels::page>
     <div class="space-y-6">
-        {{-- Health Overview Cards --}}
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            @foreach($this->getHealthCards() as $card)
-                <x-filament::card>
-                    <div class="flex items-center space-x-3">
-                        <div class="flex-shrink-0">
-                            <x-filament::icon 
-                                :icon="$card['icon']" 
-                                class="w-8 h-8 text-{{ $card['color'] }}-500"
-                            />
-                        </div>
-                        <div class="flex-1 min-w-0">
-                            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                                {{ $card['label'] }}
-                            </p>
-                            <p class="text-2xl font-bold text-{{ $card['color'] }}-600 dark:text-{{ $card['color'] }}-400">
-                                {{ $card['value'] }}
-                            </p>
-                            <p class="text-xs text-gray-500 dark:text-gray-400">
-                                {{ $card['description'] }}
-                            </p>
-                        </div>
-                    </div>
-                </x-filament::card>
-            @endforeach
-        </div>
+        {{-- Widgets are automatically rendered by Filament via getHeaderWidgets() --}}
 
-        {{-- System Components Status --}}
-        <x-filament::card>
-            <div class="px-4 py-5 sm:p-6">
-                <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
-                    System Components
-                </h3>
-                <div class="space-y-3">
-                    @foreach($healthData['components'] ?? [] as $component => $status)
-                        <div class="flex items-center justify-between py-2 border-b border-gray-200 dark:border-gray-700 last:border-b-0">
-                            <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                                {{ $component }}
-                            </span>
-                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-{{ $this->getComponentStatusColor($status) }}-100 text-{{ $this->getComponentStatusColor($status) }}-800 dark:bg-{{ $this->getComponentStatusColor($status) }}-900 dark:text-{{ $this->getComponentStatusColor($status) }}-200">
-                                {{ $status }}
-                            </span>
-                        </div>
-                    @endforeach
-                </div>
-            </div>
-        </x-filament::card>
+        {{-- Additional content will be displayed below the widgets --}}
 
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {{-- Performance Metrics --}}
-            <x-filament::card>
-                <div class="px-4 py-5 sm:p-6">
-                    <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
-                        Performance Metrics
-                    </h3>
-                    <div class="space-y-3">
-                        @foreach($healthData['performance'] ?? [] as $metric => $value)
-                            <div class="flex items-center justify-between">
-                                <span class="text-sm text-gray-600 dark:text-gray-400">
-                                    {{ $metric }}
-                                </span>
-                                <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                                    {{ $value }}
-                                </span>
-                            </div>
-                        @endforeach
-                    </div>
-                </div>
-            </x-filament::card>
+        <div class="grid grid-cols-1 gap-6">
 
             {{-- Recommendations --}}
             <x-filament::card>


### PR DESCRIPTION
## Summary
Replace custom health cards with genuine Filament v4 widgets in system health page - Two rows of 4x25% width widgets with auto-refresh and proper health data integration

## Changes
- app/Filament/Pages/McpSystemHealth.php
- resources/views/filament/pages/mcp-system-health.blade.php

🤖 Generated with [Claude Code](https://claude.ai/code)