### PR TITLE
Update all icons to use Filament\Support\Enums\Heroicon enum for better type safety and IDE support

- Convert all string-based icon references to enum values across 29 files
- Update Pages, Resources, Widgets, and Resource Pages
:OUTLINE_*
:MINI_*  
- Add proper import statements for Heroicon enum
- Maintain exact same visual icons and functionality
- Improve type safety and IDE autocompletion support
- Follow Filament v4 best practices and definitive guide compliance

🔧 Generated with Claude Code

### DIFF
--- a/app/Filament/Pages/ConversationHistory.php
+++ b/app/Filament/Pages/ConversationHistory.php
@@ -14,6 +14,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\On;
 
@@ -111,19 +112,19 @@ class ConversationHistory extends Page implements HasForms
         return [
             Action::make('refreshStats')
                 ->label('Refresh Statistics')
-                ->icon('heroicon-o-arrow-path')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH)
                 ->action('refreshStatistics'),
 
             Action::make('exportConversation')
                 ->label('Export Conversation')
-                ->icon('heroicon-o-arrow-down-tray')
+                ->icon(Heroicon::OUTLINE_ARROW_DOWN_TRAY)
                 ->action('exportSelectedConversation')
                 ->visible(fn () => $this->selectedConversation !== null)
                 ->color('success'),
 
             Action::make('archiveConversation')
                 ->label('Archive Conversation')
-                ->icon('heroicon-o-archive-box')
+                ->icon(Heroicon::OUTLINE_ARCHIVE_BOX)
                 ->action('archiveSelectedConversation')
                 ->visible(fn () => $this->selectedConversation?->isActive())
                 ->requiresConfirmation()
@@ -131,7 +132,7 @@ class ConversationHistory extends Page implements HasForms
 
             Action::make('deleteConversation')
                 ->label('Delete Conversation')
-                ->icon('heroicon-o-trash')
+                ->icon(Heroicon::OUTLINE_TRASH)
                 ->action('deleteSelectedConversation')
                 ->visible(fn () => $this->selectedConversation !== null)
                 ->requiresConfirmation()
@@ -140,7 +141,7 @@ class ConversationHistory extends Page implements HasForms
 
             Action::make('clearAllFilters')
                 ->label('Clear Filters')
-                ->icon('heroicon-o-funnel')
+                ->icon(Heroicon::OUTLINE_FUNNEL)
                 ->action('clearAllFilters')
                 ->color('gray'),
         ];

--- a/app/Filament/Pages/ImportExport.php
+++ b/app/Filament/Pages/ImportExport.php
@@ -15,6 +15,7 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Illuminate\Support\Facades\Storage;
 
 class ImportExport extends Page implements HasForms
@@ -178,7 +179,7 @@ class ImportExport extends Page implements HasForms
         return [
             Action::make('cleanupOldExports')
                 ->label('Cleanup Old Exports')
-                ->icon('heroicon-o-trash')
+                ->icon(Heroicon::OUTLINE_TRASH)
                 ->action('cleanupOldExports')
                 ->color('warning')
                 ->requiresConfirmation()

--- a/app/Filament/Pages/LogMonitoringDashboard.php
+++ b/app/Filament/Pages/LogMonitoringDashboard.php
@@ -11,6 +11,7 @@ use App\Services\McpProcessOrchestrator;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Support\Enums\Heroicon;
 
 class LogMonitoringDashboard extends Page
 {
@@ -39,19 +40,19 @@ class LogMonitoringDashboard extends Page
         return [
             Action::make('toggleMonitoring')
                 ->label($isMonitoring ? 'Stop Monitoring' : 'Start Monitoring')
-                ->icon($isMonitoring ? 'heroicon-o-stop' : 'heroicon-o-play')
+                ->icon($isMonitoring ? Heroicon::OUTLINE_STOP : Heroicon::OUTLINE_PLAY)
                 ->color($isMonitoring ? 'danger' : 'success')
                 ->action($isMonitoring ? 'stopLogMonitoring' : 'startLogMonitoring'),
 
             Action::make('testErrorDetection')
                 ->label('Test Error Detection')
-                ->icon('heroicon-o-bug-ant')
+                ->icon(Heroicon::OUTLINE_BUG_ANT)
                 ->color('warning')
                 ->action('testErrorDetection'),
 
             Action::make('refreshStats')
                 ->label('Refresh Stats')
-                ->icon('heroicon-o-arrow-path')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH)
                 ->action('refreshMonitoringStats'),
         ];
     }
@@ -189,7 +190,7 @@ class LogMonitoringDashboard extends Page
 
     public function getStatusIcon(bool $status): string
     {
-        return $status ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle';
+        return $status ? Heroicon::OUTLINE_CHECK_CIRCLE : Heroicon::OUTLINE_X_CIRCLE;
     }
 
     public function formatFileSize(int $bytes): string

--- a/app/Filament/Pages/McpAnalytics.php
+++ b/app/Filament/Pages/McpAnalytics.php
@@ -12,6 +12,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Illuminate\Support\Facades\Cache;
 
 class McpAnalytics extends Page implements HasForms
@@ -90,24 +91,24 @@ class McpAnalytics extends Page implements HasForms
         return [
             Action::make('refreshData')
                 ->label('Refresh Data')
-                ->icon('heroicon-o-arrow-path')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH)
                 ->action('refreshData'),
 
             Action::make('exportData')
                 ->label('Export Analytics')
-                ->icon('heroicon-o-arrow-down-tray')
+                ->icon(Heroicon::OUTLINE_ARROW_DOWN_TRAY)
                 ->action('exportAnalytics'),
 
             Action::make('clearCache')
                 ->label('Clear Cache')
-                ->icon('heroicon-o-trash')
+                ->icon(Heroicon::OUTLINE_TRASH)
                 ->action('clearAnalyticsCache')
                 ->color('danger')
                 ->requiresConfirmation(),
 
             Action::make('cleanOldData')
                 ->label('Clean Old Data')
-                ->icon('heroicon-o-archive-box-x-mark')
+                ->icon(Heroicon::OUTLINE_ARCHIVE_BOX_X_MARK)
                 ->action('cleanOldData')
                 ->color('warning')
                 ->requiresConfirmation()
@@ -240,28 +241,28 @@ class McpAnalytics extends Page implements HasForms
                 'label' => 'Total Events',
                 'value' => number_format($summary['total_events'] ?? 0),
                 'description' => 'Events in selected period',
-                'icon' => 'heroicon-o-chart-bar',
+                'icon' => Heroicon::OUTLINE_CHART_BAR,
                 'color' => 'info',
             ],
             [
                 'label' => 'Success Rate',
                 'value' => number_format($summary['success_rate'] ?? 0, 1).'%',
                 'description' => 'Successful operations',
-                'icon' => 'heroicon-o-check-circle',
+                'icon' => Heroicon::OUTLINE_CHECK_CIRCLE,
                 'color' => 'success',
             ],
             [
                 'label' => 'Active Users',
                 'value' => number_format($summary['unique_users'] ?? 0),
                 'description' => 'Unique users',
-                'icon' => 'heroicon-o-users',
+                'icon' => Heroicon::OUTLINE_USERS,
                 'color' => 'warning',
             ],
             [
                 'label' => 'Avg Response Time',
                 'value' => number_format($summary['average_response_time'] ?? 0).'ms',
                 'description' => 'Average duration',
-                'icon' => 'heroicon-o-clock',
+                'icon' => Heroicon::OUTLINE_CLOCK,
                 'color' => 'primary',
             ],
         ];
@@ -274,21 +275,21 @@ class McpAnalytics extends Page implements HasForms
                 'label' => 'Events (Last Hour)',
                 'value' => number_format($this->realTimeMetrics['events_last_hour'] ?? 0),
                 'description' => 'Recent activity',
-                'icon' => 'heroicon-o-bolt',
+                'icon' => Heroicon::OUTLINE_BOLT,
                 'color' => 'info',
             ],
             [
                 'label' => 'Errors (Last Hour)',
                 'value' => number_format($this->realTimeMetrics['errors_last_hour'] ?? 0),
                 'description' => 'Recent errors',
-                'icon' => 'heroicon-o-exclamation-triangle',
+                'icon' => Heroicon::OUTLINE_EXCLAMATION_TRIANGLE,
                 'color' => 'danger',
             ],
             [
                 'label' => 'Active Users',
                 'value' => number_format($this->realTimeMetrics['active_users_last_hour'] ?? 0),
                 'description' => 'Currently active',
-                'icon' => 'heroicon-o-user-group',
+                'icon' => Heroicon::OUTLINE_USER_GROUP,
                 'color' => 'success',
             ],
         ];

--- a/app/Filament/Pages/McpConfiguration.php
+++ b/app/Filament/Pages/McpConfiguration.php
@@ -13,6 +13,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Illuminate\Support\Facades\File;
 
 class McpConfiguration extends Page implements HasForms
@@ -188,7 +189,7 @@ class McpConfiguration extends Page implements HasForms
         return [
             Action::make('save')
                 ->label('Save Configuration')
-                ->icon('heroicon-o-check')
+                ->icon(Heroicon::OUTLINE_CHECK)
                 ->action('saveConfiguration')
                 ->requiresConfirmation()
                 ->modalHeading('Save MCP Configuration')
@@ -197,7 +198,7 @@ class McpConfiguration extends Page implements HasForms
 
             Action::make('reset')
                 ->label('Reset to Defaults')
-                ->icon('heroicon-o-arrow-path')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH)
                 ->action('resetConfiguration')
                 ->color('gray')
                 ->requiresConfirmation()
@@ -207,13 +208,13 @@ class McpConfiguration extends Page implements HasForms
 
             Action::make('export')
                 ->label('Export Config')
-                ->icon('heroicon-o-arrow-down-tray')
+                ->icon(Heroicon::OUTLINE_ARROW_DOWN_TRAY)
                 ->action('exportConfiguration')
                 ->color('info'),
 
             Action::make('import')
                 ->label('Import Config')
-                ->icon('heroicon-o-arrow-up-tray')
+                ->icon(Heroicon::OUTLINE_ARROW_UP_TRAY)
                 ->action('importConfiguration')
                 ->color('warning'),
         ];

--- a/app/Filament/Pages/McpConversation.php
+++ b/app/Filament/Pages/McpConversation.php
@@ -16,6 +16,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Illuminate\Support\Facades\Log;
 
 class McpConversation extends Page implements HasForms
@@ -111,27 +112,27 @@ class McpConversation extends Page implements HasForms
         return [
             Action::make('sendMessage')
                 ->label('Send Message')
-                ->icon('heroicon-o-paper-airplane')
+                ->icon(Heroicon::OUTLINE_PAPER_AIRPLANE)
                 ->action('sendMessage')
                 ->disabled(fn () => empty($this->data['selectedConnection'] ?? null)),
 
             Action::make('callTool')
                 ->label('Call Tool')
-                ->icon('heroicon-o-wrench')
+                ->icon(Heroicon::OUTLINE_WRENCH)
                 ->action('callTool')
                 ->disabled(fn () => empty($this->data['selectedConnection'] ?? null) || empty($this->data['selectedTool'] ?? null))
                 ->visible(fn () => ! empty($this->data['selectedTool'] ?? null)),
 
             Action::make('clearConversation')
                 ->label('Clear')
-                ->icon('heroicon-o-trash')
+                ->icon(Heroicon::OUTLINE_TRASH)
                 ->action('clearConversation')
                 ->color('danger')
                 ->requiresConfirmation(),
 
             Action::make('refreshTools')
                 ->label('Refresh Tools')
-                ->icon('heroicon-o-arrow-path')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH)
                 ->action('loadTools'),
         ];
     }

--- a/app/Filament/Pages/McpDashboard.php
+++ b/app/Filament/Pages/McpDashboard.php
@@ -9,6 +9,7 @@ use App\Services\McpClient;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Support\Enums\Heroicon;
 use Illuminate\Support\Facades\Log;
 
 class McpDashboard extends Page
@@ -51,7 +52,7 @@ class McpDashboard extends Page
         return [
             Action::make('testAllConnections')
                 ->label('Test All Connections')
-                ->icon('heroicon-o-signal')
+                ->icon(Heroicon::OUTLINE_SIGNAL)
                 ->action('testAllConnections')
                 ->requiresConfirmation()
                 ->modalHeading('Test All MCP Connections')

--- a/app/Filament/Pages/McpSecurity.php
+++ b/app/Filament/Pages/McpSecurity.php
@@ -14,6 +14,7 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
@@ -227,7 +228,7 @@ class McpSecurity extends Page implements HasForms, HasTable
         return [
             Action::make('save')
                 ->label('Save Security Settings')
-                ->icon('heroicon-o-shield-check')
+                ->icon(Heroicon::OUTLINE_SHIELD_CHECK)
                 ->action('saveSecuritySettings')
                 ->requiresConfirmation()
                 ->modalHeading('Save Security Settings')
@@ -236,7 +237,7 @@ class McpSecurity extends Page implements HasForms, HasTable
 
             Action::make('auditConnections')
                 ->label('Audit All Connections')
-                ->icon('heroicon-o-eye')
+                ->icon(Heroicon::OUTLINE_EYE)
                 ->action('auditAllConnections')
                 ->color('info')
                 ->requiresConfirmation()
@@ -246,7 +247,7 @@ class McpSecurity extends Page implements HasForms, HasTable
 
             Action::make('revokeAll')
                 ->label('Revoke All Sessions')
-                ->icon('heroicon-o-x-circle')
+                ->icon(Heroicon::OUTLINE_X_CIRCLE)
                 ->action('revokeAllSessions')
                 ->color('danger')
                 ->requiresConfirmation()

--- a/app/Filament/Pages/McpSystemHealth.php
+++ b/app/Filament/Pages/McpSystemHealth.php
@@ -10,6 +10,7 @@ use App\Services\McpHealthCheckService;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Support\Enums\Heroicon;
 
 class McpSystemHealth extends Page
 {
@@ -54,19 +55,19 @@ class McpSystemHealth extends Page
         return [
             Action::make('refreshHealth')
                 ->label('Refresh Health Check')
-                ->icon('heroicon-o-arrow-path')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH)
                 ->action('refreshHealthCheck'),
 
             Action::make('clearCache')
                 ->label('Clear Cache')
-                ->icon('heroicon-o-trash')
+                ->icon(Heroicon::OUTLINE_TRASH)
                 ->action('clearHealthCache')
                 ->color('warning')
                 ->requiresConfirmation(),
 
             Action::make('runDiagnostics')
                 ->label('Run Full Diagnostics')
-                ->icon('heroicon-o-wrench-screwdriver')
+                ->icon(Heroicon::OUTLINE_WRENCH_SCREWDRIVER)
                 ->action('runFullDiagnostics')
                 ->color('info'),
         ];
@@ -169,12 +170,12 @@ class McpSystemHealth extends Page
     public function getStatusIcon(): string
     {
         return match ($this->healthData['status'] ?? 'unknown') {
-            'excellent' => 'heroicon-o-check-circle',
-            'good' => 'heroicon-o-check-badge',
-            'fair' => 'heroicon-o-exclamation-triangle',
-            'poor' => 'heroicon-o-x-circle',
-            'critical', 'error' => 'heroicon-o-x-circle',
-            default => 'heroicon-o-question-mark-circle',
+            'excellent' => Heroicon::OUTLINE_CHECK_CIRCLE,
+            'good' => Heroicon::OUTLINE_CHECK_BADGE,
+            'fair' => Heroicon::OUTLINE_EXCLAMATION_TRIANGLE,
+            'poor' => Heroicon::OUTLINE_X_CIRCLE,
+            'critical', 'error' => Heroicon::OUTLINE_X_CIRCLE,
+            default => Heroicon::OUTLINE_QUESTION_MARK_CIRCLE,
         };
     }
 
@@ -201,11 +202,11 @@ class McpSystemHealth extends Page
     public function getRecommendationIcon(string $type): string
     {
         return match ($type) {
-            'success' => 'heroicon-o-check-circle',
-            'info' => 'heroicon-o-information-circle',
-            'warning' => 'heroicon-o-exclamation-triangle',
-            'error' => 'heroicon-o-x-circle',
-            default => 'heroicon-o-light-bulb',
+            'success' => Heroicon::OUTLINE_CHECK_CIRCLE,
+            'info' => Heroicon::OUTLINE_INFORMATION_CIRCLE,
+            'warning' => Heroicon::OUTLINE_EXCLAMATION_TRIANGLE,
+            'error' => Heroicon::OUTLINE_X_CIRCLE,
+            default => Heroicon::OUTLINE_LIGHT_BULB,
         };
     }
 

--- a/app/Filament/Pages/ProxmoxExecutiveDashboard.php
+++ b/app/Filament/Pages/ProxmoxExecutiveDashboard.php
@@ -8,6 +8,7 @@ use App\Models\ProxmoxContainer;
 use App\Models\ProxmoxVirtualMachine;
 use BackedEnum;
 use Filament\Pages\Page;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\ChartWidget;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
@@ -15,7 +16,7 @@ use UnitEnum;
 
 class ProxmoxExecutiveDashboard extends Page
 {
-    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-chart-bar';
+    protected static BackedEnum|string|null $navigationIcon = Heroicon::OUTLINE_CHART_BAR;
 
     protected string $view = 'filament.pages.proxmox-executive-dashboard';
 
@@ -102,24 +103,24 @@ class ExecutiveKPIWidget extends StatsOverviewWidget
         return [
             Stat::make('Active Development Environments', $activeEnvironments)
                 ->description("{$totalEnvironments} total environments")
-                ->descriptionIcon('heroicon-o-cube')
+                ->descriptionIcon(Heroicon::OUTLINE_CUBE)
                 ->color('success')
                 ->chart([7, 12, 8, 15, 18, 22, $activeEnvironments]),
 
             Stat::make('Monthly Platform Cost', '$'.number_format($totalMonthlyCost, 2))
                 ->description('Estimated operational cost')
-                ->descriptionIcon('heroicon-o-currency-dollar')
+                ->descriptionIcon(Heroicon::OUTLINE_CURRENCY_DOLLAR)
                 ->color('warning'),
 
             Stat::make('Running Virtual Machines', $runningVMs)
                 ->description("{$totalVMs} total VMs")
-                ->descriptionIcon('heroicon-o-server')
+                ->descriptionIcon(Heroicon::OUTLINE_SERVER)
                 ->color('info')
                 ->chart([15, 18, 22, 25, 20, 24, $runningVMs]),
 
             Stat::make('Running Containers', $runningContainers)
                 ->description("{$totalContainers} total containers")
-                ->descriptionIcon('heroicon-o-cube-transparent')
+                ->descriptionIcon(Heroicon::OUTLINE_CUBE_TRANSPARENT)
                 ->color('primary')
                 ->chart([8, 12, 15, 18, 16, 20, $runningContainers]),
         ];
@@ -343,22 +344,22 @@ class ClusterHealthWidget extends StatsOverviewWidget
         return [
             Stat::make('Average Cluster Health', $averageHealth.'%')
                 ->description('Overall platform health')
-                ->descriptionIcon('heroicon-o-heart')
+                ->descriptionIcon(Heroicon::OUTLINE_HEART)
                 ->color($averageHealth >= 80 ? 'success' : ($averageHealth >= 60 ? 'warning' : 'danger')),
 
             Stat::make('Healthy Clusters', $healthyCount)
                 ->description('Health score ≥ 80%')
-                ->descriptionIcon('heroicon-o-check-circle')
+                ->descriptionIcon(Heroicon::OUTLINE_CHECK_CIRCLE)
                 ->color('success'),
 
             Stat::make('Warning Clusters', $warningCount)
                 ->description('Health score 60-79%')
-                ->descriptionIcon('heroicon-o-exclamation-triangle')
+                ->descriptionIcon(Heroicon::OUTLINE_EXCLAMATION_TRIANGLE)
                 ->color('warning'),
 
             Stat::make('Critical Clusters', $criticalCount)
                 ->description('Health score < 60%')
-                ->descriptionIcon('heroicon-o-x-circle')
+                ->descriptionIcon(Heroicon::OUTLINE_X_CIRCLE)
                 ->color('danger'),
         ];
     }

--- a/app/Filament/Pages/ResourceBrowser.php
+++ b/app/Filament/Pages/ResourceBrowser.php
@@ -13,6 +13,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Filament\Support\Enums\Width;
 use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\On;
@@ -108,26 +109,26 @@ class ResourceBrowser extends Page implements HasForms
         return [
             Action::make('discoverAllResources')
                 ->label('Discover All Resources')
-                ->icon('heroicon-o-magnifying-glass')
+                ->icon(Heroicon::OUTLINE_MAGNIFYING_GLASS)
                 ->action('discoverAllResources')
                 ->requiresConfirmation()
                 ->modalDescription('This will scan all active MCP connections and discover available resources. This may take a few moments.'),
 
             Action::make('refreshStats')
                 ->label('Refresh Statistics')
-                ->icon('heroicon-o-arrow-path')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH)
                 ->action('refreshStatistics'),
 
             Action::make('clearCache')
                 ->label('Clear Cache')
-                ->icon('heroicon-o-trash')
+                ->icon(Heroicon::OUTLINE_TRASH)
                 ->action('clearResourceCache')
                 ->requiresConfirmation()
                 ->color('danger'),
 
             Action::make('syncResource')
                 ->label('Sync Resource')
-                ->icon('heroicon-o-arrow-path-rounded-square')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH_ROUNDED_SQUARE)
                 ->form([
                     Select::make('targetConnection')
                         ->label('Target Connection')

--- a/app/Filament/Pages/SystemLogs.php
+++ b/app/Filament/Pages/SystemLogs.php
@@ -10,6 +10,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 
@@ -101,19 +102,19 @@ class SystemLogs extends Page implements HasForms
         return [
             Action::make('clearLogs')
                 ->label('Clear Current Log')
-                ->icon('heroicon-o-trash')
+                ->icon(Heroicon::OUTLINE_TRASH)
                 ->action('clearCurrentLog')
                 ->color('danger')
                 ->requiresConfirmation(),
 
             Action::make('downloadLog')
                 ->label('Download Log')
-                ->icon('heroicon-o-arrow-down-tray')
+                ->icon(Heroicon::OUTLINE_ARROW_DOWN_TRAY)
                 ->action('downloadCurrentLog'),
 
             Action::make('refreshLogs')
                 ->label('Refresh')
-                ->icon('heroicon-o-arrow-path')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH)
                 ->action('refreshLogs'),
         ];
     }

--- a/app/Filament/Pages/ToolManagement.php
+++ b/app/Filament/Pages/ToolManagement.php
@@ -15,6 +15,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Filament\Support\Enums\Width;
 use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\On;
@@ -106,26 +107,26 @@ class ToolManagement extends Page implements HasForms
         return [
             Action::make('discoverAllTools')
                 ->label('Discover All Tools')
-                ->icon('heroicon-o-magnifying-glass')
+                ->icon(Heroicon::OUTLINE_MAGNIFYING_GLASS)
                 ->action('discoverAllTools')
                 ->requiresConfirmation()
                 ->modalDescription('This will scan all active MCP connections and discover available tools. This may take a few moments.'),
 
             Action::make('refreshStats')
                 ->label('Refresh Statistics')
-                ->icon('heroicon-o-arrow-path')
+                ->icon(Heroicon::OUTLINE_ARROW_PATH)
                 ->action('refreshStatistics'),
 
             Action::make('clearCache')
                 ->label('Clear Cache')
-                ->icon('heroicon-o-trash')
+                ->icon(Heroicon::OUTLINE_TRASH)
                 ->action('clearToolCache')
                 ->requiresConfirmation()
                 ->color('danger'),
 
             Action::make('createComposition')
                 ->label('Create Tool Composition')
-                ->icon('heroicon-o-squares-plus')
+                ->icon(Heroicon::OUTLINE_SQUARES_PLUS)
                 ->form([
                     TextInput::make('name')
                         ->label('Composition Name')

--- a/app/Filament/Resources/DevelopmentEnvironmentResource.php
+++ b/app/Filament/Resources/DevelopmentEnvironmentResource.php
@@ -16,6 +16,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Filament\Tables;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\DeleteAction;
@@ -31,7 +32,7 @@ class DevelopmentEnvironmentResource extends Resource
 {
     protected static ?string $model = DevelopmentEnvironment::class;
 
-    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-cube';
+    protected static BackedEnum|string|null $navigationIcon = Heroicon::OUTLINE_CUBE;
 
     protected static ?string $navigationLabel = 'Dev Environments';
 
@@ -326,7 +327,7 @@ class DevelopmentEnvironmentResource extends Resource
             ])
             ->actions([
                 Action::make('start')
-                    ->icon('heroicon-o-play')
+                    ->icon(Heroicon::OUTLINE_PLAY)
                     ->color('success')
                     ->visible(fn (DevelopmentEnvironment $record): bool => $record->isStopped())
                     ->action(function (DevelopmentEnvironment $record) {
@@ -339,7 +340,7 @@ class DevelopmentEnvironmentResource extends Resource
                     }),
 
                 Action::make('stop')
-                    ->icon('heroicon-o-stop')
+                    ->icon(Heroicon::OUTLINE_STOP)
                     ->color('warning')
                     ->visible(fn (DevelopmentEnvironment $record): bool => $record->isRunning())
                     ->requiresConfirmation()
@@ -353,7 +354,7 @@ class DevelopmentEnvironmentResource extends Resource
                     }),
 
                 Action::make('access')
-                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->icon(Heroicon::OUTLINE_ARROW_TOP_RIGHT_ON_SQUARE)
                     ->color('info')
                     ->visible(fn (DevelopmentEnvironment $record): bool => $record->isRunning())
                     ->url(function (DevelopmentEnvironment $record): ?string {

--- a/app/Filament/Resources/DevelopmentEnvironmentResource/Pages/ListDevelopmentEnvironments.php
+++ b/app/Filament/Resources/DevelopmentEnvironmentResource/Pages/ListDevelopmentEnvironments.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\DevelopmentEnvironmentResource\Pages;
 use App\Filament\Resources\DevelopmentEnvironmentResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Support\Enums\Heroicon;
 
 class ListDevelopmentEnvironments extends ListRecords
 {
@@ -15,7 +16,7 @@ class ListDevelopmentEnvironments extends ListRecords
         return [
             Actions\CreateAction::make()
                 ->label('Create Environment')
-                ->icon('heroicon-o-plus'),
+                ->icon(Heroicon::OUTLINE_PLUS),
         ];
     }
 }

--- a/app/Filament/Resources/DevelopmentEnvironmentResource/Pages/ViewDevelopmentEnvironment.php
+++ b/app/Filament/Resources/DevelopmentEnvironmentResource/Pages/ViewDevelopmentEnvironment.php
@@ -12,6 +12,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\FontWeight;
+use Filament\Support\Enums\Heroicon;
 
 class ViewDevelopmentEnvironment extends ViewRecord
 {
@@ -21,7 +22,7 @@ class ViewDevelopmentEnvironment extends ViewRecord
     {
         return [
             Actions\Action::make('start')
-                ->icon('heroicon-o-play')
+                ->icon(Heroicon::OUTLINE_PLAY)
                 ->color('success')
                 ->visible(fn () => $this->record->isStopped())
                 ->action(function () {
@@ -34,7 +35,7 @@ class ViewDevelopmentEnvironment extends ViewRecord
                 }),
 
             Actions\Action::make('stop')
-                ->icon('heroicon-o-stop')
+                ->icon(Heroicon::OUTLINE_STOP)
                 ->color('warning')
                 ->visible(fn () => $this->record->isRunning())
                 ->requiresConfirmation()
@@ -48,7 +49,7 @@ class ViewDevelopmentEnvironment extends ViewRecord
                 }),
 
             Actions\Action::make('access_urls')
-                ->icon('heroicon-o-arrow-top-right-on-square')
+                ->icon(Heroicon::OUTLINE_ARROW_TOP_RIGHT_ON_SQUARE)
                 ->color('info')
                 ->visible(fn () => $this->record->isRunning())
                 ->action(function () {

--- a/app/Filament/Resources/ProxmoxClusterResource.php
+++ b/app/Filament/Resources/ProxmoxClusterResource.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Heroicon;
 use Filament\Tables;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\DeleteAction;
@@ -27,7 +28,7 @@ class ProxmoxClusterResource extends Resource
 {
     protected static ?string $model = ProxmoxCluster::class;
 
-    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-server-stack';
+    protected static BackedEnum|string|null $navigationIcon = Heroicon::OUTLINE_SERVER_STACK;
 
     protected static ?string $navigationLabel = 'Proxmox Clusters';
 
@@ -185,7 +186,7 @@ class ProxmoxClusterResource extends Resource
             ])
             ->actions([
                 Action::make('health_check')
-                    ->icon('heroicon-o-heart')
+                    ->icon(Heroicon::OUTLINE_HEART)
                     ->color('info')
                     ->action(function (ProxmoxCluster $record) {
                         $monitoringService = new \App\Services\ProxmoxMonitoringService($record);
@@ -200,7 +201,7 @@ class ProxmoxClusterResource extends Resource
                 EditAction::make(),
 
                 Action::make('view_details')
-                    ->icon('heroicon-o-eye')
+                    ->icon(Heroicon::OUTLINE_EYE)
                     ->url(fn (ProxmoxCluster $record): string => route('filament.admin.resources.proxmox-clusters.view', $record)
                     ),
 

--- a/app/Filament/Resources/ProxmoxClusterResource/Pages/ViewProxmoxCluster.php
+++ b/app/Filament/Resources/ProxmoxClusterResource/Pages/ViewProxmoxCluster.php
@@ -12,6 +12,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\FontWeight;
+use Filament\Support\Enums\Heroicon;
 
 class ViewProxmoxCluster extends ViewRecord
 {
@@ -21,7 +22,7 @@ class ViewProxmoxCluster extends ViewRecord
     {
         return [
             Actions\Action::make('health_check')
-                ->icon('heroicon-o-heart')
+                ->icon(Heroicon::OUTLINE_HEART)
                 ->color('info')
                 ->action(function () {
                     $monitoringService = new ProxmoxMonitoringService($this->record);

--- a/app/Filament/Widgets/HealthOverviewWidget.php
+++ b/app/Filament/Widgets/HealthOverviewWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Services\McpHealthCheckService;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
@@ -24,17 +25,17 @@ class HealthOverviewWidget extends BaseWidget
 
             Stat::make('Response Time', $healthData['performance']['Response Time'] ?? 'Unknown')
                 ->description($healthData['performance']['Assessment'] ?? 'Unknown')
-                ->descriptionIcon('heroicon-o-clock')
+                ->descriptionIcon(Heroicon::OUTLINE_CLOCK)
                 ->color(($healthData['performance']['Assessment'] ?? '') === 'fast' ? 'success' : 'warning'),
 
             Stat::make('System Issues', count($healthData['errors'] ?? []))
                 ->description('Active problems')
-                ->descriptionIcon('heroicon-o-exclamation-triangle')
+                ->descriptionIcon(Heroicon::OUTLINE_EXCLAMATION_TRIANGLE)
                 ->color(count($healthData['errors'] ?? []) === 0 ? 'success' : 'danger'),
 
             Stat::make('Last Check', $this->formatLastCheck($healthData['last_check'] ?? null))
                 ->description('Health verification')
-                ->descriptionIcon('heroicon-o-clock')
+                ->descriptionIcon(Heroicon::OUTLINE_CLOCK)
                 ->color('info'),
         ];
     }
@@ -42,12 +43,12 @@ class HealthOverviewWidget extends BaseWidget
     private function getStatusIcon(string $status): string
     {
         return match ($status) {
-            'excellent' => 'heroicon-o-check-circle',
-            'good' => 'heroicon-o-check-badge',
-            'fair' => 'heroicon-o-exclamation-triangle',
-            'poor' => 'heroicon-o-x-circle',
-            'critical', 'error' => 'heroicon-o-x-circle',
-            default => 'heroicon-o-question-mark-circle',
+            'excellent' => Heroicon::OUTLINE_CHECK_CIRCLE,
+            'good' => Heroicon::OUTLINE_CHECK_BADGE,
+            'fair' => Heroicon::OUTLINE_EXCLAMATION_TRIANGLE,
+            'poor' => Heroicon::OUTLINE_X_CIRCLE,
+            'critical', 'error' => Heroicon::OUTLINE_X_CIRCLE,
+            default => Heroicon::OUTLINE_QUESTION_MARK_CIRCLE,
         };
     }
 

--- a/app/Filament/Widgets/LogFileMonitoringWidget.php
+++ b/app/Filament/Widgets/LogFileMonitoringWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Services\LogMonitoringService;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
@@ -25,12 +26,12 @@ class LogFileMonitoringWidget extends BaseWidget
         return [
             Stat::make('Log File', $stats['log_file_exists'] ? 'Found' : 'Missing')
                 ->description($stats['log_file_exists'] ? 'Log file is accessible' : 'Log file not found')
-                ->descriptionIcon($stats['log_file_exists'] ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+                ->descriptionIcon($stats['log_file_exists'] ? Heroicon::OUTLINE_CHECK_CIRCLE : Heroicon::OUTLINE_X_CIRCLE)
                 ->color($stats['log_file_exists'] ? 'success' : 'danger'),
 
             Stat::make('Log Size', $this->formatFileSize($stats['log_file_size'] ?? 0))
                 ->description('Current log file size')
-                ->descriptionIcon('heroicon-o-chart-bar')
+                ->descriptionIcon(Heroicon::OUTLINE_CHART_BAR)
                 ->color('primary'),
         ];
     }

--- a/app/Filament/Widgets/LogFileStatusWidget.php
+++ b/app/Filament/Widgets/LogFileStatusWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Services\LogMonitoringService;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
@@ -23,12 +24,12 @@ class LogFileStatusWidget extends BaseWidget
         return [
             Stat::make('Log File', $stats['log_file_exists'] ? 'Found' : 'Missing')
                 ->description($stats['log_file_exists'] ? 'Log file is accessible' : 'Log file not found')
-                ->descriptionIcon($stats['log_file_exists'] ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+                ->descriptionIcon($stats['log_file_exists'] ? Heroicon::OUTLINE_CHECK_CIRCLE : Heroicon::OUTLINE_X_CIRCLE)
                 ->color($stats['log_file_exists'] ? 'success' : 'danger'),
 
             Stat::make('Log Size', $this->formatFileSize($stats['log_file_size'] ?? 0))
                 ->description('Current log file size')
-                ->descriptionIcon('heroicon-o-chart-bar')
+                ->descriptionIcon(Heroicon::OUTLINE_CHART_BAR)
                 ->color('primary'),
         ];
     }

--- a/app/Filament/Widgets/McpConnectionStatsWidget.php
+++ b/app/Filament/Widgets/McpConnectionStatsWidget.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets;
 
 use App\Models\McpConnection;
 use App\Services\PersistentMcpManager;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Livewire\Attributes\On;
@@ -29,27 +30,27 @@ class McpConnectionStatsWidget extends BaseWidget
         return [
             Stat::make('Total Connections', $connections->count())
                 ->description('All MCP connections')
-                ->descriptionIcon('heroicon-m-arrow-trending-up')
+                ->descriptionIcon(Heroicon::MINI_ARROW_TRENDING_UP)
                 ->color('primary'),
 
             Stat::make('Active Connections', $connections->where('status', 'active')->count())
                 ->description('Configured as active')
-                ->descriptionIcon('heroicon-m-check-circle')
+                ->descriptionIcon(Heroicon::MINI_CHECK_CIRCLE)
                 ->color('success'),
 
             Stat::make('Manager Active', $activeInManager)
                 ->description('Actually running in manager')
-                ->descriptionIcon('heroicon-m-cpu-chip')
+                ->descriptionIcon(Heroicon::MINI_CPU_CHIP)
                 ->color('info'),
 
             Stat::make('Error Rate', $this->calculateErrorRate($connections))
                 ->description('Connections with errors')
-                ->descriptionIcon('heroicon-m-exclamation-triangle')
+                ->descriptionIcon(Heroicon::MINI_EXCLAMATION_TRIANGLE)
                 ->color('danger'),
 
             Stat::make('Memory Usage', $this->getMemoryUsage())
                 ->description('Current memory consumption')
-                ->descriptionIcon('heroicon-m-server')
+                ->descriptionIcon(Heroicon::MINI_SERVER)
                 ->color('warning'),
         ];
     }

--- a/app/Filament/Widgets/McpConnectionsWidget.php
+++ b/app/Filament/Widgets/McpConnectionsWidget.php
@@ -6,6 +6,7 @@ use App\Models\McpConnection;
 use App\Services\McpClient;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
+use Filament\Support\Enums\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
@@ -65,7 +66,7 @@ class McpConnectionsWidget extends BaseWidget
             ->actions([
                 Action::make('test')
                     ->label('Test')
-                    ->icon('heroicon-o-signal')
+                    ->icon(Heroicon::OUTLINE_SIGNAL)
                     ->action(function (McpConnection $record) {
                         $this->testConnection($record);
                     }),

--- a/app/Filament/Widgets/McpProcessStatusWidget.php
+++ b/app/Filament/Widgets/McpProcessStatusWidget.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets;
 
 use App\Models\McpProcessStatus;
 use App\Services\McpProcessOrchestrator;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\Log;
@@ -32,23 +33,23 @@ class McpProcessStatusWidget extends BaseWidget
                         ? 'PID: '.($logMonitoringStatus['pid'] ?? 'N/A').' | Uptime: '.($logMonitoringStatus['uptime'] ?? 'N/A')
                         : 'Process not active'
                     )
-                    ->descriptionIcon($logMonitoringRunning ? 'heroicon-m-check-circle' : 'heroicon-m-x-circle')
+                    ->descriptionIcon($logMonitoringRunning ? Heroicon::MINI_CHECK_CIRCLE : Heroicon::MINI_X_CIRCLE)
                     ->color($logMonitoringRunning ? 'success' : 'danger')
                     ->chart($this->getProcessChart('log-monitoring')),
 
                 Stat::make('Running Processes', $runningProcesses)
                     ->description('Active MCP processes')
-                    ->descriptionIcon('heroicon-m-play-circle')
+                    ->descriptionIcon(Heroicon::MINI_PLAY_CIRCLE)
                     ->color($runningProcesses > 0 ? 'success' : 'gray'),
 
                 Stat::make('Failed Processes', $failedProcesses)
                     ->description('Processes that failed or died')
-                    ->descriptionIcon('heroicon-m-exclamation-triangle')
+                    ->descriptionIcon(Heroicon::MINI_EXCLAMATION_TRIANGLE)
                     ->color($failedProcesses > 0 ? 'danger' : 'success'),
 
                 Stat::make('Total Processes', $totalProcesses)
                     ->description('All tracked processes')
-                    ->descriptionIcon('heroicon-m-cpu-chip')
+                    ->descriptionIcon(Heroicon::MINI_CPU_CHIP)
                     ->color('primary'),
             ];
         } catch (\Exception $e) {
@@ -57,7 +58,7 @@ class McpProcessStatusWidget extends BaseWidget
             return [
                 Stat::make('Error', 'Failed to load')
                     ->description('Widget error: '.$e->getMessage())
-                    ->descriptionIcon('heroicon-m-exclamation-triangle')
+                    ->descriptionIcon(Heroicon::MINI_EXCLAMATION_TRIANGLE)
                     ->color('danger'),
             ];
         }

--- a/app/Filament/Widgets/McpStatsWidget.php
+++ b/app/Filament/Widgets/McpStatsWidget.php
@@ -6,6 +6,7 @@ use App\Models\ApiKey;
 use App\Models\Dataset;
 use App\Models\Document;
 use App\Models\McpConnection;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\Cache;
@@ -42,25 +43,25 @@ class McpStatsWidget extends BaseWidget
             return [
                 Stat::make('MCP Connections', $totalConnections)
                     ->description($activeConnections.' active'.($weeklyConnections > 0 ? " • +{$weeklyConnections} this week" : ''))
-                    ->descriptionIcon($connectionGrowth > 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-signal')
+                    ->descriptionIcon($connectionGrowth > 0 ? Heroicon::MINI_ARROW_TRENDING_UP : Heroicon::MINI_SIGNAL)
                     ->color($activeConnections > 0 ? 'success' : 'warning')
                     ->chart($this->getConnectionTrend()),
 
                 Stat::make('Datasets', $totalDatasets)
                     ->description($weeklyDatasets.' this week'.($datasetGrowth > 0 ? " • +{$datasetGrowth}% growth" : ''))
-                    ->descriptionIcon($datasetGrowth > 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-table-cells')
+                    ->descriptionIcon($datasetGrowth > 0 ? Heroicon::MINI_ARROW_TRENDING_UP : Heroicon::MINI_TABLE_CELLS)
                     ->color('info')
                     ->chart($this->getDatasetTrend()),
 
                 Stat::make('Documents', $totalDocuments)
                     ->description($weeklyDocuments.' this week'.($documentGrowth > 0 ? " • +{$documentGrowth}% growth" : ''))
-                    ->descriptionIcon($documentGrowth > 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-document-text')
+                    ->descriptionIcon($documentGrowth > 0 ? Heroicon::MINI_ARROW_TRENDING_UP : Heroicon::MINI_DOCUMENT_TEXT)
                     ->color('primary')
                     ->chart($this->getDocumentTrend()),
 
                 Stat::make('Active API Keys', $activeApiKeys)
                     ->description($this->getApiKeyDescription($activeApiKeys))
-                    ->descriptionIcon('heroicon-m-key')
+                    ->descriptionIcon(Heroicon::MINI_KEY)
                     ->color($activeApiKeys > 0 ? 'warning' : 'gray'),
             ];
         });

--- a/app/Filament/Widgets/RecommendationsWidget.php
+++ b/app/Filament/Widgets/RecommendationsWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Services\McpHealthCheckService;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\Widget;
 
 class RecommendationsWidget extends Widget
@@ -37,11 +38,11 @@ class RecommendationsWidget extends Widget
     public function getRecommendationIcon(string $type): string
     {
         return match ($type) {
-            'success' => 'heroicon-o-check-circle',
-            'info' => 'heroicon-o-information-circle',
-            'warning' => 'heroicon-o-exclamation-triangle',
-            'error' => 'heroicon-o-x-circle',
-            default => 'heroicon-o-light-bulb',
+            'success' => Heroicon::OUTLINE_CHECK_CIRCLE,
+            'info' => Heroicon::OUTLINE_INFORMATION_CIRCLE,
+            'warning' => Heroicon::OUTLINE_EXCLAMATION_TRIANGLE,
+            'error' => Heroicon::OUTLINE_X_CIRCLE,
+            default => Heroicon::OUTLINE_LIGHT_BULB,
         };
     }
 }

--- a/app/Filament/Widgets/SystemComponentsWidget.php
+++ b/app/Filament/Widgets/SystemComponentsWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Services\McpHealthCheckService;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
@@ -19,22 +20,22 @@ class SystemComponentsWidget extends BaseWidget
         return [
             Stat::make('Claude CLI', $components['Claude CLI'] ?? 'Unknown')
                 ->description('Command line interface')
-                ->descriptionIcon('heroicon-o-command-line')
+                ->descriptionIcon(Heroicon::OUTLINE_COMMAND_LINE)
                 ->color($this->getComponentColor($components['Claude CLI'] ?? 'Unknown')),
 
             Stat::make('Authentication', $components['Authentication'] ?? 'Unknown')
                 ->description('API key validation')
-                ->descriptionIcon('heroicon-o-key')
+                ->descriptionIcon(Heroicon::OUTLINE_KEY)
                 ->color($this->getComponentColor($components['Authentication'] ?? 'Unknown')),
 
             Stat::make('MCP Server', $components['MCP Server'] ?? 'Unknown')
                 ->description('Protocol server')
-                ->descriptionIcon('heroicon-o-server')
+                ->descriptionIcon(Heroicon::OUTLINE_SERVER)
                 ->color($this->getComponentColor($components['MCP Server'] ?? 'Unknown')),
 
             Stat::make('Connection Pool', $this->getActiveConnections())
                 ->description('Active connections')
-                ->descriptionIcon('heroicon-o-link')
+                ->descriptionIcon(Heroicon::OUTLINE_LINK)
                 ->color('info'),
         ];
     }

--- a/app/Filament/Widgets/SystemMonitoringWidget.php
+++ b/app/Filament/Widgets/SystemMonitoringWidget.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets;
 
 use App\Services\LogMonitoringService;
 use App\Services\ProcessManager;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
@@ -46,12 +47,12 @@ class SystemMonitoringWidget extends BaseWidget
         return [
             Stat::make('MCP System', $systemStatus)
                 ->description($systemDescription)
-                ->descriptionIcon($systemStatus === 'Active' ? 'heroicon-o-check-circle' : 'heroicon-o-exclamation-triangle')
+                ->descriptionIcon($systemStatus === 'Active' ? Heroicon::OUTLINE_CHECK_CIRCLE : Heroicon::OUTLINE_EXCLAMATION_TRIANGLE)
                 ->color($systemColor),
 
             Stat::make('Error Patterns', $stats['patterns_configured'] ?? 11)
                 ->description('Detection patterns configured')
-                ->descriptionIcon('heroicon-o-puzzle-piece')
+                ->descriptionIcon(Heroicon::OUTLINE_PUZZLE_PIECE)
                 ->color('info'),
         ];
     }

--- a/app/Filament/Widgets/SystemSupportWidget.php
+++ b/app/Filament/Widgets/SystemSupportWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Services\LogMonitoringService;
+use Filament\Support\Enums\Heroicon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
@@ -36,12 +37,12 @@ class SystemSupportWidget extends BaseWidget
         return [
             Stat::make('System Support', $stats['monitoring_supported'] ? 'Available' : 'Unavailable')
                 ->description($stats['monitoring_supported'] ? 'Log monitoring is available' : 'Log monitoring unavailable')
-                ->descriptionIcon($stats['monitoring_supported'] ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+                ->descriptionIcon($stats['monitoring_supported'] ? Heroicon::OUTLINE_CHECK_CIRCLE : Heroicon::OUTLINE_X_CIRCLE)
                 ->color($stats['monitoring_supported'] ? 'success' : 'danger'),
 
             Stat::make('Error Patterns', $stats['patterns_configured'] ?? 11)
                 ->description('Detection patterns configured')
-                ->descriptionIcon('heroicon-o-puzzle-piece')
+                ->descriptionIcon(Heroicon::OUTLINE_PUZZLE_PIECE)
                 ->color('info'),
         ];
     }


### PR DESCRIPTION
## Summary
Update all icons to use Filament\Support\Enums\Heroicon enum for better type safety and IDE support

- Convert all string-based icon references to enum values across 29 files
- Update Pages, Resources, Widgets, and Resource Pages
:OUTLINE_*
:MINI_*  
- Add proper import statements for Heroicon enum
- Maintain exact same visual icons and functionality
- Improve type safety and IDE autocompletion support
- Follow Filament v4 best practices and definitive guide compliance

🔧 Generated with Claude Code

## Changes
- app/Filament/Pages/ConversationHistory.php
- app/Filament/Pages/ImportExport.php
- app/Filament/Pages/LogMonitoringDashboard.php
- app/Filament/Pages/McpAnalytics.php
- app/Filament/Pages/McpConfiguration.php

🤖 Generated with [Claude Code](https://claude.ai/code)