### PR TITLE
Fix SQLite compatibility in AnalyticsManager for HOUR function

- Replace MySQL HOUR(created_at) with SQLite-compatible strftime('%H', created_at)  
1 no such function: HOUR' in MCP Analytics page
- Maintain exact same functionality with proper SQLite date/time functions
- Cast result as INTEGER to ensure proper numeric sorting

🔧 Generated with Claude Code

### DIFF
--- a/app/Services/AnalyticsManager.php
+++ b/app/Services/AnalyticsManager.php
@@ -313,7 +313,7 @@ class AnalyticsManager
             ->get();
 
         $usersByHour = McpAnalytics::selectRaw('
-            HOUR(created_at) as hour,
+            CAST(strftime(\'%H\', created_at) AS INTEGER) as hour,
             COUNT(DISTINCT user_id) as unique_users,
             COUNT(*) as total_events
         ')


### PR DESCRIPTION
## Summary
Fix SQLite compatibility in AnalyticsManager for HOUR function

- Replace MySQL HOUR(created_at) with SQLite-compatible strftime('%H', created_at)  
1 no such function: HOUR' in MCP Analytics page
- Maintain exact same functionality with proper SQLite date/time functions
- Cast result as INTEGER to ensure proper numeric sorting

🔧 Generated with Claude Code

## Changes
- app/Services/AnalyticsManager.php

🤖 Generated with [Claude Code](https://claude.ai/code)